### PR TITLE
Included Web Counter API Call

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,6 +737,8 @@
             window.open(pdfPath,'_blank');
         }
     </script> 
+    
+<script async src="https://api.countapi.xyz/hit/prabinrath.github.io/00768ece-ccf6-499d-bbfa-89ad9b9f64e1"></script>
 </body>
 
 </html>


### PR DESCRIPTION
- Used countapi.xyz  API for counting number of hits to the page.
- To get the number of hit points use the  below URL :  https://api.countapi.xyz/get/prabinrath.github.io/00768ece-ccf6-499d-bbfa-89ad9b9f64e1